### PR TITLE
Fixed Ranchers tls-ca secret

### DIFF
--- a/roles/rke_rancher_clusters/tasks/rancher.yml
+++ b/roles/rke_rancher_clusters/tasks/rancher.yml
@@ -83,15 +83,15 @@
     kubeconfig: "{{ rke_cluster_kube_config }}"
     state: present
     definition:
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: tls-rancher-ingress
-            namespace: cattle-system
-          data:
-            tls.crt: "{{ rke_rancher_tls_crt }}"
-            tls.key: "{{ rke_rancher_tls_key }}"
-          type: kubernetes.io/tls
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: tls-rancher-ingress
+        namespace: cattle-system
+      data:
+        tls.crt: "{{ rke_rancher_tls_crt }}"
+        tls.key: "{{ rke_rancher_tls_key }}"
+      type: kubernetes.io/tls
   when:
   - not certmanager_enabled
 
@@ -100,14 +100,13 @@
     kubeconfig: "{{ rke_cluster_kube_config }}"
     state: present
     definition:
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: tls-ca
-            namespace: cattle-system
-          data:
-            cacerts.pem: "{{ rke_rancher_tls_cacerts }}"
-          type: kubernetes.io/tls
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: tls-ca
+        namespace: cattle-system
+      data:
+        cacerts.pem: "{{ rke_rancher_tls_cacerts }}"
   when:
   - not certmanager_enabled
   - rke_rancher_tls_self_signed


### PR DESCRIPTION
Fixed by removing `type: kubernetes.io/tls` from the `tls-ca` secret