### PR TITLE
Psc/fix keepalived setup at custom cluster creation

### DIFF
--- a/roles/custom_k8s_cluster/README.md
+++ b/roles/custom_k8s_cluster/README.md
@@ -45,51 +45,12 @@ custom_k8s_cluster_agent_version: "v2.4.5"
 # Base command for the Ranger Agent
 custom_k8s_cluster_docker_commmand_base: "docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:{{ custom_k8s_cluster_agent_version}} --server https://{{ custom_k8s_cluster_rancher_host }}"
 
-# Custom K8s cluster vIP HA setup
-# Useful when you want built-in HA for your custom K8s cluster ingress controller without external LB
-custom_k8s_cluster_keepalived_enabled: false
-# Specify if the keepalived setup should only use a private IP.
-# If so, set "custom_k8s_cluster_keepalived_private_only" to "true"
-# and leave all "*_public_*" configuration options down here empty.
-custom_k8s_cluster_keepalived_private_only: false
-# Specify if the keepalived setup should only use IPv4.
-# If so, set "custom_k8s_cluster_keepalived_ipv4_only" to "true"
-# and leave all "*_ipv6" configuration options down here empty.
-custom_k8s_cluster_keepalived_ipv4_only: false
-# Specify a node selector labels if keepalived containers should only run on certain nodes
-# If left empty, the daemonset will deploy a replica per node. For example "vip_public" and "vip_private":
-custom_k8s_cluster_keepalived_private_node_selector: "vip_private"
-custom_k8s_cluster_keepalived_public_node_selector: "vip_public"
-# Specify a node toleration label if keepalived containers should be running on tainted certain nodes
-custom_k8s_cluster_keepalived_private_node_toleration: ""
-custom_k8s_cluster_keepalived_public_node_toleration: "public_ingress"
-# Specify where the custom K8s cluster is running. Currently supported environments are:
-# - "local": Local keepalived setup
-# - "cloudscale": Keepalived setup with cloudscale floating IP
-custom_k8s_cluster_keepalived_setup_env: "local"
-# If "custom_k8s_cluster_keepalived_setup_env" is set to "cloudscale", a cloudscale API token needs to be provided.
-custom_k8s_cluster_keepalived_cloudscale_api_token: "{{ cloudscale_api_token }}"
-# Keepalived service Docker image
-custom_k8s_cluster_keepalived_image: "puzzle/keepalived:2.0.20"
-# Keepalived IP address configuration
-custom_k8s_cluster_keepalived_private_failover_track_interface_ip: eth0
-custom_k8s_cluster_keepalived_private_failover_ip:
-  - vip: "192.0.2.254"
-    router_id: 1
-    master: rancher01
-    password: my-top-secret-password1-here
-custom_k8s_cluster_keepalived_public_failover_track_interface_ip: eth0
-custom_k8s_cluster_keepalived_public_failover_ip:
-  - vip: "198.51.100.254"
-    router_id: 2
-    master: rancher01
-    password: my-top-secret-password2-here
-custom_k8s_cluster_keepalived_public_failover_track_interface_ipv6: eth0
-custom_k8s_cluster_keepalived_public_failover_ipv6:
-  - vip: "2001:db8::ffff"
-    router_id: 3
-    master: rancher01
-    password: my-top-secret-password3-here
+# Internal Interface
+# See https://rancher.com/docs/rke/latest/en/config-options/nodes/#internal-address
+# & https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/custom-nodes/agent-options/#ip-address-options
+custom_k8s_cluster_ingress_node_internal_iface: eth0
+
+custom_k8s_cluster_use_fqdn_nodename: true
 ```
 
 Dependencies

--- a/roles/custom_k8s_cluster/defaults/main.yml
+++ b/roles/custom_k8s_cluster/defaults/main.yml
@@ -29,3 +29,10 @@ custom_k8s_cluster_agent_version: "v2.4.5"
 
 # Base command for the Ranger Agent
 custom_k8s_cluster_docker_commmand_base: "docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:{{ custom_k8s_cluster_agent_version}} --server https://{{ custom_k8s_cluster_rancher_host }}"
+
+# Internal Interface
+# See https://rancher.com/docs/rke/latest/en/config-options/nodes/#internal-address
+# & https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/custom-nodes/agent-options/#ip-address-options
+custom_k8s_cluster_ingress_node_internal_iface: eth0
+
+custom_k8s_cluster_use_fqdn_nodename: true

--- a/roles/custom_k8s_cluster/tasks/cluster.yml
+++ b/roles/custom_k8s_cluster/tasks/cluster.yml
@@ -132,27 +132,32 @@
       Authorization: "Bearer {{ custom_k8s_cluster_api_key }}"
   register: clusternodecommand
   check_mode: no
-  when: custom_k8s_cluster_self_signed_certificate | bool == true
+  when:
+    - custom_k8s_cluster_self_signed_certificate
 
 - name: Filter for correct cluster clusterNodeCommand
   set_fact:
     clusternodecommand: "{{ clusternodecommand | json_query(\"json.data[?clusterId == '\" + cluster.id + \"']\") }}"
-  when: custom_k8s_cluster_self_signed_certificate | bool == true
+  when:
+    - custom_k8s_cluster_self_signed_certificate
 
 - name: Set cluster node command
   set_fact:
     clusternodecommand: "{{ clusternodecommand[0].nodeCommand }}"
-  when: custom_k8s_cluster_self_signed_certificate | bool == true
+  when:
+    - custom_k8s_cluster_self_signed_certificate
 
 - name: Parse cluster ca-checksum
   set_fact:
     clustercachecksum: "{{ clusternodecommand | regex_search(custom_k8s_cluster_ca_checksum_param | string + '(\\s+)' +'(.*)', '\\2') | first }}"
-  when: custom_k8s_cluster_self_signed_certificate | bool == true
+  when:
+    - custom_k8s_cluster_self_signed_certificate
 
 - name: Parsed ca-checksum from cluster
   debug:
     msg: "{{ clustercachecksum }}"
-  when: custom_k8s_cluster_self_signed_certificate | bool == true
+  when:
+    - custom_k8s_cluster_self_signed_certificate
 
 - name: Get KubeConfig from Rancher Control Plane
   uri:

--- a/roles/custom_k8s_cluster/tasks/main.yml
+++ b/roles/custom_k8s_cluster/tasks/main.yml
@@ -14,3 +14,8 @@
     public: yes
   vars:
     keepalived_cluster_group_inventory_name: "{{ custom_k8s_cluster_group_inventory_name }}"
+    keepalived_deployment_on_custom_cluster: true
+    keepalived_deployment_rancher_api: "{{ custom_k8s_cluster_rancher_api }}"
+    keepalived_deployment_rancher_api_key: "{{ custom_k8s_cluster_api_key }}"
+    keepalived_deployment_rancher_api_verify_ssl: "{{ custom_k8s_cluster_verify_ssl }}"
+    keepalived_deployment_rancher_cluster_id: "{{ cluster.id }}"

--- a/roles/custom_k8s_cluster/tasks/nodes.yml
+++ b/roles/custom_k8s_cluster/tasks/nodes.yml
@@ -21,9 +21,9 @@
 
 - name: Add Nodes when not already added
   delegate_to: "{{ item }}"
-  command: "{{ custom_k8s_cluster_docker_commmand_base }} {{ custom_k8s_cluster_ca_checksum_param }} {{ clustercachecksum }} --token {{ clusterregistrationtoken }} --node-name {{ hostvars[item]['ansible_facts']['hostname'] }}{{ '.' if hostvars[item]['ansible_facts']['domain'] else '' }}{{ hostvars[item]['ansible_facts']['domain'] }}{% for label in hostvars[item]['k8s_labels'] %} --label {{ label.name }}={{ label.value }}{% endfor %}{% for role in hostvars[item]['k8s_roles'] %} --{{ role }}{% endfor %}"
+  command: "{{ custom_k8s_cluster_docker_commmand_base }} {{ custom_k8s_cluster_ca_checksum_param }} {{ clustercachecksum | default('') }} --token {{ clusterregistrationtoken }} --internal-address {{ custom_k8s_cluster_ingress_node_internal_iface }} --node-name {{ hostvars[item]['ansible_facts']['hostname'] }}{{ '.' + hostvars[item]['ansible_facts']['domain'] if hostvars[item]['ansible_facts']['domain'] and custom_k8s_cluster_use_fqdn_nodename else '' }}{% for label in hostvars[item]['k8s_labels'] %} --label {{ label.name }}={{ label.value }}{% endfor %}{% for role in hostvars[item]['k8s_roles'] %} --{{ role }}{% endfor %}"
   when:
-    - (cluster_nodes | json_query("json.data[?hostname == '" + hostvars[item]['ansible_facts']['hostname'] + "." + hostvars[item]['ansible_facts']['domain'] +"']") | length) == 0
+    - (cluster_nodes | json_query("json.data[?hostname == '" + hostvars[item]['ansible_facts']['hostname'] + ("." + hostvars[item]['ansible_facts']['domain'] if hostvars[item]['ansible_facts']['domain'] and custom_k8s_cluster_use_fqdn_nodename else "") +"']") | length) == 0
   with_items:
     - "{{ groups[custom_k8s_cluster_group_inventory_name] }}"
   ignore_errors: yes

--- a/roles/custom_k8s_cluster/tasks/nodes.yml
+++ b/roles/custom_k8s_cluster/tasks/nodes.yml
@@ -16,6 +16,8 @@
 - name: Show nodes which are going to be added
   debug:
     msg: "{{ hostvars[item]['ansible_facts']['hostname'] }}{{ '.' if hostvars[item]['ansible_facts']['domain'] else '' }}{{ hostvars[item]['ansible_facts']['domain'] }}"
+  when:
+    - (cluster_nodes | json_query("json.data[?hostname == '" + hostvars[item]['ansible_facts']['hostname'] + ("." + hostvars[item]['ansible_facts']['domain'] if hostvars[item]['ansible_facts']['domain'] and custom_k8s_cluster_use_fqdn_nodename else "") +"']") | length) == 0
   with_items:
     - "{{ groups[custom_k8s_cluster_group_inventory_name] }}"
 

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -6,7 +6,8 @@ Install keepalived daemonset on an existing K8s cluster
 Requirements
 ------------
 
-Only uses python and ansible.
+- Only uses python and ansible.
+- The keepalived daemonset pods only come up when the host port 80 becomes reachable (≃ an ingress controller is running)
 
 
 Role Variables

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -41,6 +41,14 @@ keepalived_setup_env: "local"
 keepalived_cloudscale_api_token: "{{ cloudscale_api_token }}"
 # Keepalived service Docker image
 keepalived_image: "puzzle/keepalived:2.0.20"
+# Specify if keepalived daemonset deployment destination is on a custom K8s cluster.
+# If set to true, the keepalived role waits with its tasks until the destination cluster is ready and not in transitioning state
+keepalived_deployment_on_custom_cluster: false
+# If "keepalived_deployment_on_custom_cluster" is set to true the following Rancher API related variables ("keepalived_deployment_rancher_*") need to be set too.
+keepalived_deployment_rancher_api: "https://rancher.example.com/v3"
+keepalived_deployment_rancher_api_key: ""
+keepalived_deployment_rancher_api_verify_ssl: yes
+keepalived_deployment_rancher_cluster_id: ""
 # Keepalived IP address configuration
 keepalived_private_failover_track_interface_ip: eth0
 keepalived_private_failover_ip:
@@ -60,6 +68,18 @@ keepalived_public_failover_ipv6:
     router_id: 3
     master: rancher01
     password: my-top-secret-password3-here
+# Node groups to deploy keepalived on
+# Usually the default variable "keepalived_cluster_group_inventory_name" is replaces with "custom_k8s_cluster_group_inventory_name" or 
+# "rke_cluster_group_inventory_name" for example - depending from which other role this keepalived role is called.
+keepalived_cluster_group_inventory_name: "{{ inventory_hostname | regex_replace('rancher_') }}"
+# Node groups
+# Example: If you would like to split keepalived daemonsets to different host groups:
+#   - private IPv4: "{{ groups[keepalived_cluster_group_inventory_name + '_master'] }}"
+#   - public IPv4: "{{ groups[keepalived_cluster_group_inventory_name + '_ingress'] }}"
+#   - public IPv6: "{{ groups[keepalived_cluster_group_inventory_name + '_ingress'] }}"
+keepalived_private_node_group_ipv4: "{{ keepalived_cluster_group_inventory_name }}"
+keepalived_public_node_group_ipv4: "{{ keepalived_cluster_group_inventory_name }}"
+keepalived_public_node_group_ipv6: "{{ keepalived_cluster_group_inventory_name }}"
 ```
 
 Dependencies

--- a/roles/keepalived/README.md
+++ b/roles/keepalived/README.md
@@ -17,6 +17,12 @@ Role Variables
 # Custom K8s cluster vIP HA setup
 # Useful when you want built-in HA for your custom K8s cluster ingress controller without external LB
 keepalived_enabled: false
+# Set the keepaliveds namespace name
+keepalived_ns: ipfailover
+# Move the keelalived namespace to the Rancher System project
+keepalived_ns_to_system_project: true
+# Configure Rancher System project PSP to: "none", "restricted" or "unrestricted" (only works when "keepalived_ns_to_system_project" is true)
+keepalived_rancher_system_project_psp: unrestricted
 # Specify if the keepalived setup should only use a private IP.
 # If so, set "keepalived_private_only" to "true"
 # and leave all "*_public_*" configuration options down here empty.
@@ -36,16 +42,16 @@ keepalived_public_node_toleration: ""
 # Specify where the custom K8s cluster is running. Currently supported environments are:
 # - "local": Local keepalived setup
 # - "cloudscale": Keepalived setup with cloudscale floating IP
-keepalived_setup_env: "local"
+keepalived_setup_env: local
 # If "keepalived_setup_env" is set to "cloudscale", a cloudscale API token needs to be provided.
 keepalived_cloudscale_api_token: "{{ cloudscale_api_token }}"
 # Keepalived service Docker image
-keepalived_image: "puzzle/keepalived:2.0.20"
+keepalived_image: puzzle/keepalived:2.0.20
 # Specify if keepalived daemonset deployment destination is on a custom K8s cluster.
 # If set to true, the keepalived role waits with its tasks until the destination cluster is ready and not in transitioning state
 keepalived_deployment_on_custom_cluster: false
 # If "keepalived_deployment_on_custom_cluster" is set to true the following Rancher API related variables ("keepalived_deployment_rancher_*") need to be set too.
-keepalived_deployment_rancher_api: "https://rancher.example.com/v3"
+keepalived_deployment_rancher_api: https://rancher.example.com/v3
 keepalived_deployment_rancher_api_key: ""
 keepalived_deployment_rancher_api_verify_ssl: yes
 keepalived_deployment_rancher_cluster_id: ""

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -2,6 +2,12 @@
 # Custom K8s cluster vIP HA setup
 # Useful when you want built-in HA for your custom K8s cluster ingress controller without external LB
 keepalived_enabled: false
+# Set the keepaliveds namespace name
+keepalived_ns: ipfailover
+# Move the keelalived namespace to the Rancher System project
+keepalived_ns_to_system_project: true
+# Configure Rancher System project PSP to: "none", "restricted" or "unrestricted" (only works when "keepalived_ns_to_system_project" is true)
+keepalived_rancher_system_project_psp: unrestricted
 # Specify if the keepalived setup should only use a private IP.
 # If so, set "keepalived_private_only" to "true"
 # and leave all "*_public_*" configuration options down here empty.
@@ -21,16 +27,16 @@ keepalived_public_node_toleration: ""
 # Specify where the custom K8s cluster is running. Currently supported environments are:
 # - "local": Local keepalived setup
 # - "cloudscale": Keepalived setup with cloudscale floating IP
-keepalived_setup_env: "local"
+keepalived_setup_env: local
 # If "keepalived_setup_env" is set to "cloudscale", a cloudscale API token needs to be provided.
 keepalived_cloudscale_api_token: "{{ cloudscale_api_token }}"
 # Keepalived service Docker image
-keepalived_image: "puzzle/keepalived:2.0.20"
+keepalived_image: puzzle/keepalived:2.0.20
 # Specify if keepalived daemonset deployment destination is on a custom K8s cluster.
 # If set to true, the keepalived role waits with its tasks until the destination cluster is ready and not in transitioning state
 keepalived_deployment_on_custom_cluster: false
 # If "keepalived_deployment_on_custom_cluster" is set to true the following Rancher API related variables ("keepalived_deployment_rancher_*") need to be set too.
-keepalived_deployment_rancher_api: "https://rancher.example.com/v3"
+keepalived_deployment_rancher_api: https://rancher.example.com/v3
 keepalived_deployment_rancher_api_key: ""
 keepalived_deployment_rancher_api_verify_ssl: yes
 keepalived_deployment_rancher_cluster_id: ""

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -26,6 +26,14 @@ keepalived_setup_env: "local"
 keepalived_cloudscale_api_token: "{{ cloudscale_api_token }}"
 # Keepalived service Docker image
 keepalived_image: "puzzle/keepalived:2.0.20"
+# Specify if keepalived daemonset deployment destination is on a custom K8s cluster.
+# If set to true, the keepalived role waits with its tasks until the destination cluster is ready and not in transitioning state
+keepalived_deployment_on_custom_cluster: false
+# If "keepalived_deployment_on_custom_cluster" is set to true the following Rancher API related variables ("keepalived_deployment_rancher_*") need to be set too.
+keepalived_deployment_rancher_api: "https://rancher.example.com/v3"
+keepalived_deployment_rancher_api_key: ""
+keepalived_deployment_rancher_api_verify_ssl: yes
+keepalived_deployment_rancher_cluster_id: ""
 # Keepalived IP address configuration
 keepalived_private_failover_track_interface_ip: eth0
 keepalived_private_failover_ip:

--- a/roles/keepalived/tasks/configure-keepalived.yml
+++ b/roles/keepalived/tasks/configure-keepalived.yml
@@ -54,21 +54,13 @@
     - keepalived_ns_to_system_project
     - (rancherprojects | length) > 0
 
-- name: URL encode the Rancher System project ID
-  set_fact:
-    ranchersystemprojectid_url_encoded: "{{ ranchersystemprojectid | regex_replace(':','%3A') | string }}"
-  when:
-    - keepalived_deployment_on_custom_cluster
-    - keepalived_ns_to_system_project
-    - (rancherprojects | length) > 0
-
 - name: Print Rancher System project ID
   debug:
     msg: "{{ ranchersystemprojectid }}"
   when:
     - keepalived_deployment_on_custom_cluster
-    - (ranchersystemprojectid | length) > 0
     - keepalived_ns_to_system_project
+    - (ranchersystemprojectid | length) > 0
 
 - name: Move the keepalived namespace to the Rancher System project
   uri:
@@ -89,7 +81,7 @@
 
 - name: Set System project to PSP "unrestricted"
   uri:
-    url: "{{ keepalived_deployment_rancher_api }}/projects/{{ ranchersystemprojectid_url_encoded | first }}?action=setpodsecuritypolicytemplate"
+    url: "{{ keepalived_deployment_rancher_api }}/projects/{{ ranchersystemprojectid | first }}?action=setpodsecuritypolicytemplate"
     validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
     return_content: yes
     headers:

--- a/roles/keepalived/tasks/configure-keepalived.yml
+++ b/roles/keepalived/tasks/configure-keepalived.yml
@@ -43,33 +43,32 @@
       Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
   register: rancherprojects
   when:
-    - keepalived_ns_to_system_project
     - keepalived_deployment_on_custom_cluster
+    - keepalived_ns_to_system_project
 
 - name: Get the Rancher System project ID
   set_fact:
     ranchersystemprojectid: "{{ rancherprojects | json_query(\"json.data[?name == 'System'].id\") }}"
   when:
-    - (rancherprojects | length) > 0
-    - keepalived_ns_to_system_project
     - keepalived_deployment_on_custom_cluster
+    - keepalived_ns_to_system_project
+    - (rancherprojects | length) > 0
 
 - name: URL encode the Rancher System project ID
   set_fact:
     ranchersystemprojectid_url_encoded: "{{ ranchersystemprojectid | regex_replace(':','%3A') | string }}"
   when:
-    - (rancherprojects | length) > 0
-    - ranchersystemprojectid
-    - keepalived_ns_to_system_project
     - keepalived_deployment_on_custom_cluster
+    - keepalived_ns_to_system_project
+    - (rancherprojects | length) > 0
 
 - name: Print Rancher System project ID
   debug:
     msg: "{{ ranchersystemprojectid }}"
   when:
+    - keepalived_deployment_on_custom_cluster
     - (ranchersystemprojectid | length) > 0
     - keepalived_ns_to_system_project
-    - keepalived_deployment_on_custom_cluster
 
 - name: Move the keepalived namespace to the Rancher System project
   uri:
@@ -84,13 +83,13 @@
     status_code: 200
     method: POST
   when:
-    - (ranchersystemprojectid | length) > 0
-    - keepalived_ns_to_system_project
     - keepalived_deployment_on_custom_cluster
+    - keepalived_ns_to_system_project
+    - (ranchersystemprojectid | length) > 0
 
 - name: Set System project to PSP "unrestricted"
   uri:
-    url: "{{ keepalived_deployment_rancher_api }}/projects/{{ ranchersystemprojectid_url_encoded[0] }}?action=setpodsecuritypolicytemplate"
+    url: "{{ keepalived_deployment_rancher_api }}/projects/{{ ranchersystemprojectid_url_encoded | first }}?action=setpodsecuritypolicytemplate"
     validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
     return_content: yes
     headers:
@@ -101,9 +100,9 @@
     status_code: 200
     method: POST
   when:
-    - (ranchersystemprojectid | length) > 0
-    - keepalived_ns_to_system_project
     - keepalived_deployment_on_custom_cluster
+    - keepalived_ns_to_system_project
+    - (ranchersystemprojectid | length) > 0
 
 - name: Create ConfigMap with check.py and/or notify.sh for IP Failover
   k8s:

--- a/roles/keepalived/tasks/configure-keepalived.yml
+++ b/roles/keepalived/tasks/configure-keepalived.yml
@@ -1,5 +1,19 @@
 ---
 
+- name: Wait until Cluster is ready and not in transitioning state
+  uri:
+    url: "{{ keepalived_deployment_rancher_api }}/clusters/{{ keepalived_deployment_rancher_cluster_id }}"
+    validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
+    return_content: yes
+    headers:
+      Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
+  register: cluster
+  until: cluster.json.state == "active" and cluster.json.transitioning == "no"
+  retries: 30
+  delay: 60
+  when:
+    - keepalived_deployment_on_custom_cluster
+
 - name: Create Namespace for IP Failover objects
   k8s:
     kubeconfig: "{{ kubeconfigfile }}"

--- a/roles/keepalived/tasks/configure-keepalived.yml
+++ b/roles/keepalived/tasks/configure-keepalived.yml
@@ -7,8 +7,8 @@
     return_content: yes
     headers:
       Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
-  register: cluster
-  until: cluster.json.state == "active" and cluster.json.transitioning == "no"
+  register: clusterstate
+  until: clusterstate.json.state == "active" and clusterstate.json.transitioning == "no"
   retries: 30
   delay: 60
   when:
@@ -20,7 +20,7 @@
     state: present
     api_version: v1
     kind: Namespace
-    name: ipfailover
+    name: "{{ keepalived_ns }}"
 
 - name: Create Role for privileged PSP for IP Failover
   k8s:
@@ -33,6 +33,77 @@
     kubeconfig: "{{ kubeconfigfile }}"
     state: present
     definition: "{{ lookup('file', 'default:psp:privileged.yml') }}"
+
+- name: Get all Rancher projects
+  uri:
+    url: "{{ keepalived_deployment_rancher_api }}/clusters/{{ keepalived_deployment_rancher_cluster_id }}/projects"
+    validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
+    return_content: yes
+    headers:
+      Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
+  register: rancherprojects
+  when:
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
+
+- name: Get the Rancher System project ID
+  set_fact:
+    ranchersystemprojectid: "{{ rancherprojects | json_query(\"json.data[?name == 'System'].id\") }}"
+  when:
+    - (rancherprojects | length) > 0
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
+
+- name: URL encode the Rancher System project ID
+  set_fact:
+    ranchersystemprojectid_url_encoded: "{{ ranchersystemprojectid | regex_replace(':','%3A') | string }}"
+  when:
+    - (rancherprojects | length) > 0
+    - ranchersystemprojectid
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
+
+- name: Print Rancher System project ID
+  debug:
+    msg: "{{ ranchersystemprojectid }}"
+  when:
+    - (ranchersystemprojectid | length) > 0
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
+
+- name: Move the keepalived namespace to the Rancher System project
+  uri:
+    url: "{{ keepalived_deployment_rancher_api }}/clusters/{{ keepalived_deployment_rancher_cluster_id }}/namespaces/{{ keepalived_ns }}?action=move"
+    validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
+    return_content: yes
+    headers:
+      Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
+    body:
+      projectId: "{{ ranchersystemprojectid }}"
+    body_format: json
+    status_code: 200
+    method: POST
+  when:
+    - (ranchersystemprojectid | length) > 0
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
+
+- name: Set System project to PSP "unrestricted"
+  uri:
+    url: "{{ keepalived_deployment_rancher_api }}/projects/{{ ranchersystemprojectid_url_encoded[0] }}?action=setpodsecuritypolicytemplate"
+    validate_certs: "{{ keepalived_deployment_rancher_api_verify_ssl }}"
+    return_content: yes
+    headers:
+      Authorization: "Bearer {{ keepalived_deployment_rancher_api_key }}"
+    body:
+      podSecurityPolicyTemplateId: "{{ keepalived_rancher_system_project_psp }}"
+    body_format: json
+    status_code: 200
+    method: POST
+  when:
+    - (ranchersystemprojectid | length) > 0
+    - keepalived_ns_to_system_project
+    - keepalived_deployment_on_custom_cluster
 
 - name: Create ConfigMap with check.py and/or notify.sh for IP Failover
   k8s:

--- a/roles/keepalived/templates/ds_failover.yml.j2
+++ b/roles/keepalived/templates/ds_failover.yml.j2
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ipfailover-{{ item.vip | replace(":","-")}}
-  namespace: ipfailover
+  namespace: {{ keepalived_ns }}
   labels:
     failover: failover-{{ item.vip | replace(":","-") }}
 spec:


### PR DESCRIPTION
- Fixed local custom k8s cluster keepalived setup (added wait for Rancher API)
- Fixed Rancher node add logic. Already added nodes don't get added again anymore.
- Added support to move the `ipfailover` namespace into the Rancher `System` project
- Added support to configure the PSP of the Rancher `System` project since this is required to be set to `unrestricted` with the current keepalived role