### PR TITLE
Added image cleanup and unmounting

### DIFF
--- a/plays/cleanup_k8snodes.yml
+++ b/plays/cleanup_k8snodes.yml
@@ -5,6 +5,14 @@
       shell:
         cmd: "docker rm -f $(docker ps -qa)"
       ignore_errors: True
+    - name: Unmount kubelet mounts
+      shell:
+        cmd: "for mount in $(mount | grep tmpfs | grep '/var/lib/kubelet' | awk '{ print $3 }') /var/lib/kubelet /var/lib/rancher; do umount $mount; done"
+      ignore_errors: True
+    - name: Remove Docker Images
+      shell:
+        cmd: "docker rmi -f $(docker images -q)"
+      ignore_errors: True
     - name: Remove Docker Volumes
       shell:
         cmd: "docker volume rm $(docker volume ls -q)"


### PR DESCRIPTION
According to https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cleaning-cluster-nodes/, they suggest to also remove the images. And: "Kubernetes components and secrets leave behind mounts on the system that need to be unmounted."