### PR TITLE
Fix rancher docker version dependency

### DIFF
--- a/roles/custom_k8s_cluster/README.md
+++ b/roles/custom_k8s_cluster/README.md
@@ -35,12 +35,12 @@ custom_k8s_clusters_default_psp: "restricted"
 # Enable Network Segregation between Projects
 custom_k8s_cluster_enable_network_policy: true
 # Kubernetes Version
-custom_k8s_cluster_kubernetes_version: "v1.18.6-rancher1-1"
+custom_k8s_cluster_kubernetes_version: "v1.19.4-rancher1-1"
 # Ingress Provider (none, nginx)
 custom_k8s_clusters_ingress_provider: "none"
 
 # Rancher Agent to be used
-custom_k8s_cluster_agent_version: "v2.4.5"
+custom_k8s_cluster_agent_version: "v2.4.11"
 
 # Base command for the Ranger Agent
 custom_k8s_cluster_docker_commmand_base: "docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:{{ custom_k8s_cluster_agent_version}} --server https://{{ custom_k8s_cluster_rancher_host }}"

--- a/roles/custom_k8s_cluster/defaults/main.yml
+++ b/roles/custom_k8s_cluster/defaults/main.yml
@@ -20,7 +20,7 @@ custom_k8s_clusters_default_psp: "restricted"
 # Enable Network Segregation between Projects
 custom_k8s_cluster_enable_network_policy: true
 # Kubernetes Version
-custom_k8s_cluster_kubernetes_version: "v1.19.4-rancher1-1"
+custom_k8s_cluster_kubernetes_version: "v1.18.12-rancher1-1"
 # Ingress Provider (none, nginx)
 custom_k8s_clusters_ingress_provider: "none"
 

--- a/roles/custom_k8s_cluster/defaults/main.yml
+++ b/roles/custom_k8s_cluster/defaults/main.yml
@@ -20,12 +20,12 @@ custom_k8s_clusters_default_psp: "restricted"
 # Enable Network Segregation between Projects
 custom_k8s_cluster_enable_network_policy: true
 # Kubernetes Version
-custom_k8s_cluster_kubernetes_version: "v1.18.6-rancher1-1"
+custom_k8s_cluster_kubernetes_version: "v1.19.4-rancher1-1"
 # Ingress Provider (none, nginx)
 custom_k8s_clusters_ingress_provider: "none"
 
 # Rancher Agent to be used
-custom_k8s_cluster_agent_version: "v2.4.5"
+custom_k8s_cluster_agent_version: "v2.4.11"
 
 # Base command for the Ranger Agent
 custom_k8s_cluster_docker_commmand_base: "docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:{{ custom_k8s_cluster_agent_version}} --server https://{{ custom_k8s_cluster_rancher_host }}"

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -7,6 +7,5 @@ docker_required_packages:
   - lvm2
   - pygpgme
 
-docker_pkg_repo: "https://download.docker.com/linux/centos/docker-ce.repo"
-
-docker_package: docker-ce
+# See https://github.com/rancher/install-docker for available versions.
+docker_version: "19.03"

--- a/roles/docker/tasks/docker_setup.yml
+++ b/roles/docker/tasks/docker_setup.yml
@@ -10,16 +10,18 @@
   package_facts:
     manager: auto
 
-- name: check if docker is installed and it so, get the docker version
+- name: check if docker is installed and if so, get the docker version
   shell: "docker -v | cut -d ' ' -f 3 | cut -d ',' -f 1"
+  changed_when: false
   when:
-  - "'docker' in ansible_facts.packages"
+  - "'docker-ce' in ansible_facts.packages"
   register: installed_docker_version
 
-- name: Create temporary installation script directory
+- name: create temporary installation script directory
+  changed_when: false
   tempfile:
     state: directory
-    suffix: docker_installation
+    suffix: _docker_installation
   register: docker_installation_dir
 
 - name: install Docker service
@@ -46,13 +48,13 @@
       path: "{{ docker_installation_script_full_path }}"
       state: absent
   when: (installed_docker_version is skipped or not docker_version in installed_docker_version.stdout)
-  always:
-  - name: Cleanup docker_installation_dir
-    file:
-      path: "{{ docker_installation_dir.path }}"
-      state: absent
-    when: docker_installation_dir.path is defined
 
+- name: cleanup docker_installation_dir
+  changed_when: false
+  file:
+    path: "{{ docker_installation_dir.path }}"
+    state: absent
+  when: docker_installation_dir is defined
 
 - name: Enable IP Forwarding
   sysctl:
@@ -70,6 +72,7 @@
     state: started
 
 - name: setup a cronjob for docker cleanup
+  changed_when: false
   cron:
     name: docker cleanup
     minute: "00"
@@ -79,6 +82,7 @@
     cron_file: docker_cleanup
 
 - name: setup a cronjob for docker volumes cleanup
+  changed_when: false
   cron:
     name: docker volumes cleanup
     minute: "15"
@@ -90,6 +94,6 @@
 - name: adding existing user '{{ ansible_user }}' to group docker
   user:
     name: '{{ ansible_user }}'
-    groups: docker
+    groups:
+    - docker
     append: yes
-

--- a/roles/docker/tasks/docker_setup.yml
+++ b/roles/docker/tasks/docker_setup.yml
@@ -16,6 +16,12 @@
   - "'docker' in ansible_facts.packages"
   register: installed_docker_version
 
+- name: Create temporary installation script directory
+  tempfile:
+    state: directory
+    suffix: docker_installation
+  register: docker_installation_dir
+
 - name: install Docker service
   block:
   - name: set docker installation script fact
@@ -24,12 +30,13 @@
 
   - name: set docker installation script path fact
     set_fact: 
-      docker_installation_script_full_path: "/tmp/{{ docker_installation_script }}"
+      docker_installation_script_full_path: "{{ docker_installation_dir.path }}/{{ docker_installation_script }}"
 
   - name: get Rancher's Docker installation script
     get_url:
       url: "https://releases.rancher.com/install-docker/{{ docker_installation_script }}"
       dest: "{{ docker_installation_script_full_path }}"
+      mode: '0755'
 
   - name: execute the Docker installation script
     shell: "bash {{ docker_installation_script_full_path }}"
@@ -38,7 +45,14 @@
     file: 
       path: "{{ docker_installation_script_full_path }}"
       state: absent
-  when: (installed_docker_version.stdout is undefined or not docker_version in installed_docker_version.stdout)
+  when: (installed_docker_version is skipped or not docker_version in installed_docker_version.stdout)
+  always:
+  - name: Cleanup docker_installation_dir
+    file:
+      path: "{{ docker_installation_dir.path }}"
+      state: absent
+    when: docker_installation_dir.path is defined
+
 
 - name: Enable IP Forwarding
   sysctl:

--- a/roles/docker/tasks/docker_setup.yml
+++ b/roles/docker/tasks/docker_setup.yml
@@ -18,7 +18,8 @@
 
 - name: install Docker service
   block:
-  - set_fact:
+  - name: set docker installation script facts
+    set_fact:
       docker_installation_script: "{{ docker_version }}.sh"
       docker_installation_script_full_path: "/tmp/{{ docker_installation_script }}"
 
@@ -34,9 +35,7 @@
     file: 
       path: "{{ docker_installation_script_full_path }}"
       state: absent
-  when:
-  - installed_docker_version is undefined
-  - not installed_docker_version.startswith(docker_version)
+  when: (installed_docker_version is undefined or not installed_docker_version.startswith(docker_version))
 
 - name: Enable IP Forwarding
   sysctl:

--- a/roles/docker/tasks/docker_setup.yml
+++ b/roles/docker/tasks/docker_setup.yml
@@ -6,15 +6,37 @@
     name: "{{ docker_required_packages }}"
     state: present
 
-- name: add docker repository
-  get_url:
-    url: "{{ docker_pkg_repo }}"
-    dest: /etc/yum.repos.d/docker-ce.repo
+- name: gather the package facts
+  package_facts:
+    manager: auto
 
-- name: install docker
-  yum:
-    name: "{{ docker_package }}"
-    state: present
+- name: check if docker is installed and it so, get the docker version
+  shell: "docker -v | cut -d ' ' -f 3 | cut -d ',' -f 1"
+  when:
+  - "'docker' in ansible_facts.packages"
+  register: installed_docker_version
+
+- name: install Docker service
+  block:
+  - set_fact:
+      docker_installation_script: "{{ docker_version }}.sh"
+      docker_installation_script_full_path: "/tmp/{{ docker_installation_script }}"
+
+  - name: get Rancher's Docker installation script
+    get_url:
+      url: "https://releases.rancher.com/install-docker/{{ docker_installation_script }}"
+      dest: "{{ docker_installation_script_full_path }}"
+
+  - name: execute the Docker installation script
+    shell: "{{ docker_installation_script_full_path }}"
+
+  - name: remove the Docker installation script
+    file: 
+      path: "{{ docker_installation_script_full_path }}"
+      state: absent
+  when:
+  - installed_docker_version is undefined
+  - not installed_docker_version.startswith(docker_version)
 
 - name: Enable IP Forwarding
   sysctl:

--- a/roles/docker/tasks/docker_setup.yml
+++ b/roles/docker/tasks/docker_setup.yml
@@ -18,9 +18,12 @@
 
 - name: install Docker service
   block:
-  - name: set docker installation script facts
+  - name: set docker installation script fact
     set_fact:
       docker_installation_script: "{{ docker_version }}.sh"
+
+  - name: set docker installation script path fact
+    set_fact: 
       docker_installation_script_full_path: "/tmp/{{ docker_installation_script }}"
 
   - name: get Rancher's Docker installation script
@@ -29,13 +32,13 @@
       dest: "{{ docker_installation_script_full_path }}"
 
   - name: execute the Docker installation script
-    shell: "{{ docker_installation_script_full_path }}"
+    shell: "bash {{ docker_installation_script_full_path }}"
 
   - name: remove the Docker installation script
     file: 
       path: "{{ docker_installation_script_full_path }}"
       state: absent
-  when: (installed_docker_version is undefined or not installed_docker_version.startswith(docker_version))
+  when: (installed_docker_version.stdout is undefined or not docker_version in installed_docker_version.stdout)
 
 - name: Enable IP Forwarding
   sysctl:

--- a/roles/rke_rancher_clusters/tasks/dependencies.yml
+++ b/roles/rke_rancher_clusters/tasks/dependencies.yml
@@ -13,7 +13,7 @@
     mode: 0777
   changed_when: false
 
-- name: Retrieve helm binary archive.
+- name: Retrieve helm binary archive
   unarchive:
     src: "{{ helm_binary_download_url }}"
     dest: "./"
@@ -21,7 +21,7 @@
   changed_when: false
   check_mode: no
 
-- name: Move helm binary into place.
+- name: Move helm binary into place
   copy:
     src: "linux-amd64/helm"
     dest: "{{ helm_binary }}"

--- a/roles/rke_rancher_clusters/tasks/rancher.yml
+++ b/roles/rke_rancher_clusters/tasks/rancher.yml
@@ -66,6 +66,10 @@
   when:
   - rancher_certmanager_enabled
 
+- name: Wait 20 seconds for cert-manager to properly run
+  pause:
+    seconds: "20"
+
 - name: Create tls secret when using "Bring your own certificate" Rancher certificate method (method 3)
   k8s:
     kubeconfig: "{{ rke_cluster_kube_config }}"


### PR DESCRIPTION
The `docker` role now allows it to configure the required Docker version with `docker_version` (e.g. set to `"19.03"`). Furthermore the Docker installation is now based on the official Rancher Docker installation Bash scripts.

Fixes https://github.com/puzzle/ansible-rancher/issues/25